### PR TITLE
Refractor to one backend

### DIFF
--- a/cmd/fxn/start.go
+++ b/cmd/fxn/start.go
@@ -23,7 +23,7 @@ import (
 
 func startNode(configHomePath string, cfg *config.Config, ethClient ethclient.EthClient, router contracts.Router, gatewayRegistry registry.Registry, schedulerRegistry registry.Registry, providerRegistry registry.Registry, log *zap.Logger) error {
 	rootLogger := log.Named("node")
-	modelBackendConfig, err := config.LoadModelBackendConfig(filepath.Join(configHomePath, "model_backend.yaml"))
+	modelBackendConfig, err := config.LoadModelBackend(filepath.Join(configHomePath, "model_backend.yaml"))
 	if err != nil {
 		rootLogger.Fatal("failed to load model_backend config", zap.Error(err))
 	}

--- a/fixtures/config/model_backend.yaml.template
+++ b/fixtures/config/model_backend.yaml.template
@@ -1,18 +1,7 @@
 # This is a template for the backend.yaml file.
-# It allows node operators to configure specific models and point them to different URLs (backends).
-models:
-  "Qwen3-32B":
-    url: "http://your-backend:8082"
-    fxnId: "2"
-    auth:
-      bearer_token: "api_key"
-  # "gpt-4":
-  #   url: "http://another-backend:8082"
-  #   fxnId: "3"
-  #   auth:
-  #     api_key: "your-api-key"
-  # "claude-2":
-  #   url: "http://secure-backend:8083"
-  #   fxnId: "4"
-  #   auth:
-  #     bearer_token: "your-bearer-token"
+# It allows node operators to configure a specific model and point it to a different URL (backend).
+backend_provider: "custom" # "fxn", "custom", "vllm" or "ollama"
+url: "http://your-backend:8082" # required for "custom"
+fxn_id: "2" # required for "fxn"
+api_key: "your-api-key" # optional
+bearer_token: "your-bearer-token" # optional

--- a/fixtures/tests/config/valid_model_backend.yaml
+++ b/fixtures/tests/config/valid_model_backend.yaml
@@ -1,11 +1,3 @@
-models:
-  default:
-    url: "http://default-model-backend.com"
-    fxnId: "default"
-    auth:
-      api_key: "default-api-key"
-  meta/llama-4-scout-17b-16e-instruct:
-    url: "http://llama-backend.com"
-    fxnId: "meta/llama-4-scout-17b-16e-instruct"
-    auth:
-      bearer_token: "llama-bearer-token"
+backend_provider: "fxn"
+fxn_id: "default"
+api_key: "default-api-key"

--- a/internal/config/model_backend.go
+++ b/internal/config/model_backend.go
@@ -1,10 +1,6 @@
 package config
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
 	"os"
 
@@ -12,32 +8,21 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type AuthConfig struct {
-	APIKey      string `yaml:"api_key,omitempty"`
-	BearerToken string `yaml:"bearer_token,omitempty"`
-}
-
 type ModelBackend struct {
-	URL   string      `yaml:"url"`
-	FxnID string      `yaml:"fxnId,omitempty"`
-	Auth  *AuthConfig `yaml:"auth,omitempty"`
+	BackendProvider string `yaml:"backend_provider"`
+	URL             string `yaml:"url,omitempty"`
+	FxnID           string `yaml:"fxn_id,omitempty"`
+	APIKey          string `yaml:"api_key,omitempty"`
+	BearerToken     string `yaml:"bearer_token,omitempty"`
 }
 
-type ModelBackendConfig struct {
-	Models map[string]ModelBackend `yaml:"models"`
-}
-
-type ModelExtractor struct {
-	Model string `json:"model"`
-}
-
-func LoadModelBackendConfig(configPath string) (*ModelBackendConfig, error) {
+func LoadModelBackend(configPath string) (*ModelBackend, error) {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, err
 	}
 
-	var config ModelBackendConfig
+	var config ModelBackend
 	err = yaml.Unmarshal(data, &config)
 	if err != nil {
 		return nil, err
@@ -45,43 +30,6 @@ func LoadModelBackendConfig(configPath string) (*ModelBackendConfig, error) {
 
 	return &config, nil
 }
-
-func (c *ModelBackendConfig) GetModelBackend(r *http.Request, log *zap.Logger) (*ModelBackend, error) {
-	if r.Body == nil {
-		log.Warn("request body is nil")
-		return nil, fmt.Errorf("request body is nil")
-	}
-	bodyBytes, err := io.ReadAll(r.Body)
-	if err != nil {
-		log.Warn("failed to read request body", zap.Error(err))
-		return nil, fmt.Errorf("failed to read request body: %w", err)
-	}
-	r.Body.Close()
-	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-
-	var modelExtractor ModelExtractor
-	err = json.Unmarshal(bodyBytes, &modelExtractor)
-
-	var modelName string
-	if err != nil {
-		log.Info("could not extract model from request body, using default", zap.Error(err))
-		modelName = "default"
-	} else {
-		modelName = modelExtractor.Model
-	}
-
-	modelBackend, ok := c.Models[modelName]
-	if !ok {
-		if modelName != "default" {
-			// fallback to default if model not found
-			log.Info("model not found, falling back to default", zap.String("model", modelName))
-			modelBackend, ok = c.Models["default"]
-		}
-		if !ok {
-			log.Warn("model not found in model_backend config", zap.String("model", modelName))
-			return nil, fmt.Errorf("model not found in model_backend config: %s", modelName)
-		}
-	}
-
-	return &modelBackend, nil
+func (c *ModelBackend) GetModelBackend(r *http.Request, log *zap.Logger) (*ModelBackend, error) {
+	return c, nil
 }

--- a/internal/config/model_backend_test.go
+++ b/internal/config/model_backend_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"bytes"
-	"io"
 	"net/http"
 	"testing"
 
@@ -13,35 +12,23 @@ import (
 
 func TestLoadModelBackendConfig(t *testing.T) {
 	t.Run("valid config", func(t *testing.T) {
-		config, err := LoadModelBackendConfig("../../fixtures/tests/config/valid_model_backend.yaml")
+		config, err := LoadModelBackend("../../fixtures/tests/config/valid_model_backend.yaml")
 		require.NoError(t, err)
 		require.NotNil(t, config)
 
-		assert.Len(t, config.Models, 2)
-
-		defaultModel, ok := config.Models["default"]
-		require.True(t, ok)
-		assert.Equal(t, "http://default-model-backend.com", defaultModel.URL)
-		assert.Equal(t, "default", defaultModel.FxnID)
-		require.NotNil(t, defaultModel.Auth)
-		assert.Equal(t, "default-api-key", defaultModel.Auth.APIKey)
-
-		llamaModel, ok := config.Models["meta/llama-4-scout-17b-16e-instruct"]
-		require.True(t, ok)
-		assert.Equal(t, "http://llama-backend.com", llamaModel.URL)
-		assert.Equal(t, "meta/llama-4-scout-17b-16e-instruct", llamaModel.FxnID)
-		require.NotNil(t, llamaModel.Auth)
-		assert.Equal(t, "llama-bearer-token", llamaModel.Auth.BearerToken)
+		assert.Equal(t, "fxn", config.BackendProvider)
+		assert.Equal(t, "default", config.FxnID)
+		assert.Equal(t, "default-api-key", config.APIKey)
 	})
 
 	t.Run("non-existent file", func(t *testing.T) {
-		config, err := LoadModelBackendConfig("non-existent-file.yaml")
+		config, err := LoadModelBackend("non-existent-file.yaml")
 		assert.Error(t, err)
 		assert.Nil(t, config)
 	})
 
 	t.Run("invalid yaml", func(t *testing.T) {
-		config, err := LoadModelBackendConfig("../../fixtures/tests/invalid_config/config.yaml")
+		config, err := LoadModelBackend("../../fixtures/tests/config/invalid_config.yaml")
 		assert.Error(t, err)
 		assert.Nil(t, config)
 	})
@@ -49,106 +36,15 @@ func TestLoadModelBackendConfig(t *testing.T) {
 
 func TestGetModelBackend(t *testing.T) {
 	log := zap.NewNop()
-	config, err := LoadModelBackendConfig("../../fixtures/tests/config/valid_model_backend.yaml")
+	config, err := LoadModelBackend("../../fixtures/tests/config/valid_model_backend.yaml")
 	require.NoError(t, err)
 
-	t.Run("valid model in request", func(t *testing.T) {
-		body := `{"model": "meta/llama-4-scout-17b-16e-instruct"}`
-		req, err := http.NewRequest("POST", "/", bytes.NewBufferString(body))
-		require.NoError(t, err)
+	req, err := http.NewRequest("POST", "/", bytes.NewBufferString(`{"model": "default"}`))
+	require.NoError(t, err)
 
-		modelBackend, err := config.GetModelBackend(req, log)
-		require.NoError(t, err)
-		assert.Equal(t, "http://llama-backend.com", modelBackend.URL)
-	})
-
-	t.Run("model not in config, fallback to default", func(t *testing.T) {
-		body := `{"model": "unknown-model"}`
-		req, err := http.NewRequest("POST", "/", bytes.NewBufferString(body))
-		require.NoError(t, err)
-
-		modelBackend, err := config.GetModelBackend(req, log)
-		require.NoError(t, err)
-		assert.Equal(t, "http://default-model-backend.com", modelBackend.URL)
-	})
-
-	t.Run("model not in config, no default", func(t *testing.T) {
-		configWithoutDefault := &ModelBackendConfig{
-			Models: map[string]ModelBackend{
-				"meta/llama-4-scout-17b-16e-instruct": {
-					URL: "http://llama-backend.com",
-				},
-			},
-		}
-		body := `{"model": "unknown-model"}`
-		req, err := http.NewRequest("POST", "/", bytes.NewBufferString(body))
-		require.NoError(t, err)
-
-		_, err = configWithoutDefault.GetModelBackend(req, log)
-		assert.Error(t, err)
-	})
-
-	t.Run("default model not in config", func(t *testing.T) {
-		configWithoutDefault := &ModelBackendConfig{
-			Models: map[string]ModelBackend{
-				"meta/llama-4-scout-17b-16e-instruct": {
-					URL: "http://llama-backend.com",
-				},
-			},
-		}
-		body := `{"model": "default"}`
-		req, err := http.NewRequest("POST", "/", bytes.NewBufferString(body))
-		require.NoError(t, err)
-
-		_, err = configWithoutDefault.GetModelBackend(req, log)
-		assert.Error(t, err)
-	})
-
-	t.Run("no request body", func(t *testing.T) {
-		req, err := http.NewRequest("POST", "/", nil)
-		require.NoError(t, err)
-
-		_, err = config.GetModelBackend(req, log)
-		assert.Error(t, err)
-	})
-
-	t.Run("error reading request body", func(t *testing.T) {
-		errorReader := &errorReader{}
-		req, err := http.NewRequest("POST", "/", errorReader)
-		require.NoError(t, err)
-
-		_, err = config.GetModelBackend(req, log)
-		assert.Error(t, err)
-	})
-
-	t.Run("invalid json body", func(t *testing.T) {
-		body := `invalid-json`
-		req, err := http.NewRequest("POST", "/", bytes.NewBufferString(body))
-		require.NoError(t, err)
-
-		modelBackend, err := config.GetModelBackend(req, log)
-		require.NoError(t, err)
-		assert.Equal(t, "http://default-model-backend.com", modelBackend.URL)
-	})
-
-	t.Run("request body is read twice", func(t *testing.T) {
-		body := `{"model": "meta/llama-4-scout-17b-16e-instruct"}`
-		req, err := http.NewRequest("POST", "/", bytes.NewBufferString(body))
-		require.NoError(t, err)
-
-		modelBackend, err := config.GetModelBackend(req, log)
-		require.NoError(t, err)
-		assert.Equal(t, "http://llama-backend.com", modelBackend.URL)
-
-		// Try to read the body again to ensure it was replaced
-		bodyBytes, err := io.ReadAll(req.Body)
-		require.NoError(t, err)
-		assert.Equal(t, body, string(bodyBytes))
-	})
-}
-
-type errorReader struct{}
-
-func (r *errorReader) Read(p []byte) (n int, err error) {
-	return 0, assert.AnError
+	modelBackend, err := config.GetModelBackend(req, log)
+	require.NoError(t, err)
+	assert.Equal(t, "fxn", modelBackend.BackendProvider)
+	assert.Equal(t, "default", modelBackend.FxnID)
+	assert.Equal(t, "default-api-key", modelBackend.APIKey)
 }


### PR DESCRIPTION
Our smart contracts only allow for one backend. This PR refractors model backend to reflect this and as well prepares us for when we start packaging our own inference engine and other inference engines into the node software