### PR TITLE
Add Model Alias

### DIFF
--- a/fixtures/config/model_backend.yaml.template
+++ b/fixtures/config/model_backend.yaml.template
@@ -2,7 +2,7 @@
 # It allows node operators to configure a specific model and point it to a different URL (backend).
 backendProvider: "custom" # "fxn", "custom", "vllm" or "ollama"
 url: "http://your-backend:8082" # required for "custom"
-fxnId: "2" # required for "fxn"
+fxnId: "2"
 apiKey: "your-api-key" # optional
 bearerToken: "your-bearer-token" # optional
-# modelNameAlias: "huggingface-quantized-model-name" # optional
+modelNameAlias: "huggingface-quantized-model-name"

--- a/fixtures/config/model_backend.yaml.template
+++ b/fixtures/config/model_backend.yaml.template
@@ -5,3 +5,4 @@ url: "http://your-backend:8082" # required for "custom"
 fxn_id: "2" # required for "fxn"
 api_key: "your-api-key" # optional
 bearer_token: "your-bearer-token" # optional
+# model_name_alias: "huggingface-quantized-model-name" # optional

--- a/fixtures/config/model_backend.yaml.template
+++ b/fixtures/config/model_backend.yaml.template
@@ -1,8 +1,8 @@
 # This is a template for the backend.yaml file.
 # It allows node operators to configure a specific model and point it to a different URL (backend).
-backend_provider: "custom" # "fxn", "custom", "vllm" or "ollama"
+backendProvider: "custom" # "fxn", "custom", "vllm" or "ollama"
 url: "http://your-backend:8082" # required for "custom"
-fxn_id: "2" # required for "fxn"
-api_key: "your-api-key" # optional
-bearer_token: "your-bearer-token" # optional
-# model_name_alias: "huggingface-quantized-model-name" # optional
+fxnId: "2" # required for "fxn"
+apiKey: "your-api-key" # optional
+bearerToken: "your-bearer-token" # optional
+# modelNameAlias: "huggingface-quantized-model-name" # optional

--- a/fixtures/tests/config/valid_model_backend.yaml
+++ b/fixtures/tests/config/valid_model_backend.yaml
@@ -1,3 +1,4 @@
 backend_provider: "fxn"
 fxn_id: "default"
 api_key: "default-api-key"
+model_name_alias: "aliased-model"

--- a/fixtures/tests/config/valid_model_backend.yaml
+++ b/fixtures/tests/config/valid_model_backend.yaml
@@ -1,4 +1,4 @@
-backend_provider: "fxn"
-fxn_id: "default"
-api_key: "default-api-key"
-model_name_alias: "aliased-model"
+backendProvider: "fxn"
+fxnId: "default"
+apiKey: "default-api-key"
+modelNameAlias: "aliased-model"

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -82,8 +82,8 @@ func AuthMiddleware(next http.Handler, log *zap.Logger, nonceCache *NonceCache, 
 		}
 
 		if !authenticated {
-			log.Warn("node not registered", zap.String("address", address))
-			http.Error(w, "node not registered", http.StatusUnauthorized)
+			log.Warn("caller not authorized", zap.String("address", address))
+			http.Error(w, "caller not authorized", http.StatusUnauthorized)
 			return
 		}
 

--- a/internal/config/model_backend.go
+++ b/internal/config/model_backend.go
@@ -11,10 +11,10 @@ import (
 type ModelBackend struct {
 	BackendProvider string `yaml:"backendProvider"`
 	URL             string `yaml:"url,omitempty"`
-	FxnID           string `yaml:"fxnId,omitempty"`
+	FxnID           string `yaml:"fxnId"`
 	APIKey          string `yaml:"apiKey,omitempty"`
 	BearerToken     string `yaml:"bearerToken,omitempty"`
-	ModelNameAlias  string `yaml:"modelNameAlias,omitempty"`
+	ModelNameAlias  string `yaml:"modelNameAlias"`
 }
 
 func LoadModelBackend(configPath string) (*ModelBackend, error) {

--- a/internal/config/model_backend.go
+++ b/internal/config/model_backend.go
@@ -14,6 +14,7 @@ type ModelBackend struct {
 	FxnID           string `yaml:"fxn_id,omitempty"`
 	APIKey          string `yaml:"api_key,omitempty"`
 	BearerToken     string `yaml:"bearer_token,omitempty"`
+	ModelNameAlias  string `yaml:"model_name_alias,omitempty"`
 }
 
 func LoadModelBackend(configPath string) (*ModelBackend, error) {

--- a/internal/config/model_backend.go
+++ b/internal/config/model_backend.go
@@ -9,12 +9,12 @@ import (
 )
 
 type ModelBackend struct {
-	BackendProvider string `yaml:"backend_provider"`
+	BackendProvider string `yaml:"backendProvider"`
 	URL             string `yaml:"url,omitempty"`
-	FxnID           string `yaml:"fxn_id,omitempty"`
-	APIKey          string `yaml:"api_key,omitempty"`
-	BearerToken     string `yaml:"bearer_token,omitempty"`
-	ModelNameAlias  string `yaml:"model_name_alias,omitempty"`
+	FxnID           string `yaml:"fxnId,omitempty"`
+	APIKey          string `yaml:"apiKey,omitempty"`
+	BearerToken     string `yaml:"bearerToken,omitempty"`
+	ModelNameAlias  string `yaml:"modelNameAlias,omitempty"`
 }
 
 func LoadModelBackend(configPath string) (*ModelBackend, error) {

--- a/internal/config/model_backend_test.go
+++ b/internal/config/model_backend_test.go
@@ -19,6 +19,7 @@ func TestLoadModelBackendConfig(t *testing.T) {
 		assert.Equal(t, "fxn", config.BackendProvider)
 		assert.Equal(t, "default", config.FxnID)
 		assert.Equal(t, "default-api-key", config.APIKey)
+		assert.Equal(t, "aliased-model", config.ModelNameAlias)
 	})
 
 	t.Run("non-existent file", func(t *testing.T) {

--- a/internal/openai/openai.go
+++ b/internal/openai/openai.go
@@ -76,6 +76,15 @@ func proxyRequest(r *http.Request, modelBackend *config.ModelBackend, w http.Res
 	}
 	r.Body.Close()
 
+	// Handle model name aliasing
+	if modelBackend.ModelNameAlias != "" {
+		var requestData map[string]interface{}
+		if err := json.Unmarshal(body, &requestData); err == nil {
+			requestData["model"] = modelBackend.ModelNameAlias
+			body, _ = json.Marshal(requestData)
+		}
+	}
+
 	// Create a new request to the backend URL
 	target, err := url.Parse(modelBackend.URL)
 	if err != nil {

--- a/internal/openai/openai_test.go
+++ b/internal/openai/openai_test.go
@@ -49,7 +49,7 @@ func TestNewOAIProxyHandler(t *testing.T) {
 		// Check that the body was proxied
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		assert.Equal(t, `{"model":"aliased-model-name"}`, string(body))
+		assert.Equal(t, `{"model": "aliased-model-name"}`, string(body))
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("proxied response"))
@@ -65,7 +65,7 @@ func TestNewOAIProxyHandler(t *testing.T) {
 	handler := NewOAIProxyHandler(&config.Config{}, backendConfig, log)
 
 	t.Run("successful proxy", func(t *testing.T) {
-		reqBody := `{"model": "model-1"}`
+		reqBody := `{"model": "model-1"}` // Note the space after the colon
 		req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(reqBody))
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)

--- a/internal/openai/openai_test.go
+++ b/internal/openai/openai_test.go
@@ -49,7 +49,7 @@ func TestNewOAIProxyHandler(t *testing.T) {
 		// Check that the body was proxied
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		assert.Equal(t, `{"model": "model-1"}`, string(body))
+		assert.Equal(t, `{"model":"aliased-model-name"}`, string(body))
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("proxied response"))
@@ -57,8 +57,9 @@ func TestNewOAIProxyHandler(t *testing.T) {
 	defer backendServer.Close()
 
 	backendConfig := &config.ModelBackend{
-		URL:         backendServer.URL,
-		BearerToken: "test-token",
+		URL:            backendServer.URL,
+		BearerToken:    "test-token",
+		ModelNameAlias: "aliased-model-name",
 	}
 
 	handler := NewOAIProxyHandler(&config.Config{}, backendConfig, log)


### PR DESCRIPTION
This PR allows node operators to define a different model name to match their backend when sending requests to OAI