### PR TITLE
Fix Cuda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ cuda: cuda-compile
 	@echo "Building with CUDA support..."
 	CGO_ENABLED=1 \
 	CGO_CFLAGS="-I/usr/local/cuda/include -I./cuda" \
-	CGO_LDFLAGS="-L/usr/local/cuda/lib64 -L./cuda -lmatmul_cuda -lcuda -lcudart -lcublas -lstdc++" \
+	CGO_LDFLAGS="-L/usr/local/cuda/lib64 -L./cuda/lib -lmatmul_cuda -lcuda -lcudart -lcublas -lstdc++" \
 	go build -tags cuda -o fxn github.com/fxnlabs/function-node/cmd/fxn
 
 # Compile CUDA sources


### PR DESCRIPTION
From Discord:
```txt
When manuallky compiling cuda with "make cuda" it will error out with:
```/usr/bin/ld: cannot find -lmatmul_cuda: No such file or directory
collect2: error: ld returned 1 exit status```

Because the make params are:
```Building with CUDA support...
CGO_ENABLED=1 \
CGO_CFLAGS="-I/usr/local/cuda/include -I./cuda" \
CGO_LDFLAGS="-L/usr/local/cuda/lib64 -L./cuda -lmatmul_cuda -lcuda -lcudart -lcublas -lstdc++" \
go build -tags cuda -o fxn github.com/fxnlabs/function-node/cmd/fxn```

But the `lmatmul_cuda` file is inside:
``` find . -name libmatmul_cuda.so
./cuda/lib/libmatmul_cuda.so```


Can you update this in the next release so it won't fail anymore" 
`CGO_LDFLAGS="-L./cuda/lib`
```